### PR TITLE
Adding configmaps

### DIFF
--- a/swarm-api/src/main/fabric8/fail-topic-cm.yml
+++ b/swarm-api/src/main/fabric8/fail-topic-cm.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fail.rate
+  labels:
+    strimzi.io/kind: topic
+    strimzi.io/cluster: my-cluster
+data:
+  name: fail.rate
+  partitions: "2"
+  replicas: "2"
+

--- a/swarm-api/src/main/fabric8/fail-topic-cm.yml
+++ b/swarm-api/src/main/fabric8/fail-topic-cm.yml
@@ -8,5 +8,5 @@ metadata:
 data:
   name: fail.rate
   partitions: "2"
-  replicas: "2"
+  replicas: "1"
 

--- a/swarm-api/src/main/fabric8/success-topic-cm.yml
+++ b/swarm-api/src/main/fabric8/success-topic-cm.yml
@@ -8,5 +8,5 @@ metadata:
 data:
   name: success.rate
   partitions: "2"
-  replicas: "2"
+  replicas: "1"
 

--- a/swarm-api/src/main/fabric8/success-topic-cm.yml
+++ b/swarm-api/src/main/fabric8/success-topic-cm.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: success.rate
+  labels:
+    strimzi.io/kind: topic
+    strimzi.io/cluster: my-cluster
+data:
+  name: success.rate
+  partitions: "2"
+  replicas: "2"
+


### PR DESCRIPTION
when I deploy the app (using fmp), I am see the config map being created.

But, it seems to not directly create the topic

```
oc rsh my-cluster-kafka-0

cd /var/lib/kafka/kafka-log0
ls -la
```

Gives me:
```
-rw-r--r--. 1 1000110000 root    0 May  8 04:07 cleaner-offset-checkpoint
-rw-r--r--. 1 1000110000 root    4 May  8 04:07 log-start-offset-checkpoint
-rw-r--r--. 1 1000110000 root   54 May  8 04:07 meta.properties
drwxr-xr-x. 2 1000110000 root 4096 May  8 04:07 my-topic-0
-rw-r--r--. 1 1000110000 root   17 May  8 04:07 recovery-point-offset-checkpoint
-rw-r--r--. 1 1000110000 root   17 May  8 04:08 replication-offset-checkpoint
```

Now, when I execute the app, data is written to the topic (name resolved via ENV_VAR), I notice that the content of the ConfigMap gets overridden (or created by Strimzi, since it might think it's not there?)

```
oc get configmap fail.rate -o yaml
apiVersion: v1
data:
  config: '{"segment.bytes":"1073741824"}'
  name: fail.rate
  partitions: "1"
  replicas: "1"
kind: ConfigMap
metadata:
  creationTimestamp: 2018-05-08T04:09:28Z
  labels:
    strimzi.io/cluster: my-cluster
    strimzi.io/kind: topic
  name: fail.rate
  namespace: balh
  resourceVersion: "6266"
  selfLink: /api/v1/namespaces/balh/configmaps/fail.rate
  uid: 9a2b51b5-5275-11e8-b4a3-c85b765a6fb1
```

Now, when I edit this (e.g. 3 partitions), I immediately see the result 